### PR TITLE
build: replace top level system detection with standard environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and are noted with a `!` in the message.
 
 ## Changes
 
-- ci(deps): automerge updates to dependencies that power workflow job 2026-12-16
-- fix(pkgs/gon): remove additional build flags during go compilations 2026-12-09
-- deps(ci): revert to nix installation matching this package template 2026-12-09
+- build: replace top level system detection with standard environment 2026-01-10
+- ci(deps): automerge updates to dependencies that power workflow job 2025-12-16
+- fix(pkgs/gon): remove additional build flags during go compilations 2025-12-09
+- deps(ci): revert to nix installation matching this package template 2025-12-09
 - build(ci): practice best recommendations of permission and versions 2025-08-10
 - feat(pkgs/quill): package notarization software matching goreleaser 2025-08-09
 - feat(pkgs/jtt-nvim): package a plugin to jump to tests for upstream 2025-05-24

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,10 @@
 
   etime = pkgs.callPackage ./pkgs/etime { };
   gon =
-    if pkgs.system == "x86_64-darwin" || pkgs.system == "aarch64-darwin" then
+    if
+      pkgs.stdenv.hostPlatform.system == "x86_64-darwin"
+      || pkgs.stdenv.hostPlatform.system == "aarch64-darwin"
+    then
       pkgs.callPackage ./pkgs/gon { }
     else
       null;


### PR DESCRIPTION
```
$ NIX_ABORT_ON_WARN=1 nix build --show-trace .#
...
'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```